### PR TITLE
update: Customize the text of email notifications

### DIFF
--- a/app/Events/CustomPasswordReset.php
+++ b/app/Events/CustomPasswordReset.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class CustomPasswordReset
+{
+    use SerializesModels;
+
+    public $user;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Auth\Events\PasswordReset;
+use App\Events\CustomPasswordReset as PasswordReset;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,15 +2,15 @@
 
 namespace App\Models;
 
-use App\Notifications\PasswordResetNotification;
 use App\Notifications\FullRegistrationNotification;
+use App\Notifications\PasswordResetNotification;
 use App\Notifications\VerifyEmail;
-use Laravel\Sanctum\HasApiTokens;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable implements MustVerifyEmail
 {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Notifications\PasswordResetNotification;
 use App\Notifications\FullRegistrationNotification;
 use App\Notifications\VerifyEmail;
 use Laravel\Sanctum\HasApiTokens;
@@ -60,6 +61,11 @@ class User extends Authenticatable implements MustVerifyEmail
     public function sendFullRegistrationNotification()
     {
         $this->notify(new FullRegistrationNotification());
+    }
+
+    public function sendPasswordResetNotification($token)
+    {
+        $this->notify(new PasswordResetNotification($token));
     }
 
     public function isFullRegistered(): bool

--- a/app/Notifications/PasswordResetNotification.php
+++ b/app/Notifications/PasswordResetNotification.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class PasswordResetNotification extends ResetPassword
+{
+    public function buildMailMessage($url): MailMessage
+    {
+        return (new MailMessage)
+            ->subject(__('パスワード再設定'))
+            ->line(__('下のボタンをクリックしてパスワードを再設定してください。'))
+            ->action(__('再設定'), $url)
+            ->line(__('このリンクは60分で期限切れになります。'))
+            ->line(__('もし心当たりがない場合は、このメールを破棄してください。'));
+    }
+}

--- a/resources/views/CustomPasswordResetNotification.blade.php
+++ b/resources/views/CustomPasswordResetNotification.blade.php
@@ -1,0 +1,12 @@
+<x-mail::message>
+# Introduction
+
+The body of your message.
+
+<x-mail::button :url="''">
+Button Text
+</x-mail::button>
+
+Thanks,<br>
+{{ config('app.name') }}
+</x-mail::message>

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use App\Models\User;
-use Illuminate\Auth\Notifications\ResetPassword;
+use App\Notifications\PasswordResetNotification;
 use Illuminate\Support\Facades\Notification;
 
 test('reset password link screen can be rendered', function () {
@@ -17,7 +17,7 @@ test('reset password link can be requested', function () {
 
     $this->post('/forgot-password', ['email' => $user->email]);
 
-    Notification::assertSentTo($user, ResetPassword::class);
+    Notification::assertSentTo($user, PasswordResetNotification::class);
 });
 
 test('reset password screen can be rendered', function () {
@@ -27,7 +27,7 @@ test('reset password screen can be rendered', function () {
 
     $this->post('/forgot-password', ['email' => $user->email]);
 
-    Notification::assertSentTo($user, ResetPassword::class, function ($notification) {
+    Notification::assertSentTo($user, PasswordResetNotification::class, function ($notification) {
         $response = $this->get('/reset-password/'.$notification->token);
 
         $response->assertStatus(200);
@@ -43,7 +43,7 @@ test('password can be reset with valid token', function () {
 
     $this->post('/forgot-password', ['email' => $user->email]);
 
-    Notification::assertSentTo($user, ResetPassword::class, function ($notification) use ($user) {
+    Notification::assertSentTo($user, PasswordResetNotification::class, function ($notification) use ($user) {
         $response = $this->post('/reset-password', [
             'token' => $notification->token,
             'email' => $user->email,


### PR DESCRIPTION
パスワードを忘れてしまった登録済みユーザはパスワードの再設定画面にメールアドレスを入力することでパスワードの再設定を行うことができる。
・パスワードの再設定は再設定用リンクを記載したメールが入力されたメールアドレス宛に送信されることで実現する。
・再設定用リンクは1時間の有効期限を設け、システムからの送信より1時間以上経過した場合は無効となる。